### PR TITLE
Support for open and closed sensors

### DIFF
--- a/MMM-homeassistant-sensors.js
+++ b/MMM-homeassistant-sensors.js
@@ -131,6 +131,14 @@ Module.register("MMM-homeassistant-sensors", {
 					iconsinline = document.createElement("i");
 					iconsinline.className = "mdi mdi-" + icons.state_off;
 					newCell.appendChild(iconsinline);
+				} else if (value == "open" && typeof icons.state_open === "string") {
+					iconsinline = document.createElement("i");
+					iconsinline.className = "mdi mdi-" + icons.state_open;
+					newCell.appendChild(iconsinline);
+				} else if (value == "closed" && typeof icons.state_closed === "string") {
+					iconsinline = document.createElement("i");
+					iconsinline.className = "mdi mdi-" + icons.state_closed;
+					newCell.appendChild(iconsinline);
 				} else {
 					if (typeof icons.default === "string") {
 						iconsinline = document.createElement("i");


### PR DESCRIPTION
In sensors such as that of a door cover, on and off states are not as intuitive as open and closed. Additionally, in my case my custom sensors report status as open or closed so I made this change to permit specifying dynamic icons as can currently be done in on/off sensors.