### PR TITLE
Add 'attributes' config option

### DIFF
--- a/MMM-homeassistant-sensors.js
+++ b/MMM-homeassistant-sensors.js
@@ -52,7 +52,8 @@ Module.register("MMM-homeassistant-sensors", {
         for (var i = 0; i < values.length; i++) {
           var icons = values[i].icons[0];
           var sensor = values[i].sensor;
-          var val = this.getValue(data, sensor);
+          var attributes = values[i].attributes;
+          var val = this.getValue(data, sensor, attributes);
           var name = this.getName(data, sensor);
           var unit = this.getUnit(data, sensor);
           var alertThreshold = values[i].alertThreshold;
@@ -79,10 +80,23 @@ Module.register("MMM-homeassistant-sensors", {
     }
     return wrapper;
   },
-  getValue: function(data, value) {
+  getValue: function(data, value, attributes=[]) {
     for (var i = 0; i < data.length; i++) {
       if (data[i].entity_id == value) {
-        return data[i].state;
+        if(attributes.length==0) {
+          return data[i].state;
+        }
+        var returnString = ' | ';
+        for(var j=0; j<attributes.length; j++) {
+          if(attributes[j] == 'state') {
+            returnString += data[i].state + ' | ';
+          } else {
+            if(data[i]['attributes'][attributes[j]] !== undefined) {
+              returnString += data[i]['attributes'][attributes[j]] + ' | ';
+            }
+          }
+        }
+        return returnString.slice(0, -3);
       }
     }
     return null;

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ It can display information from [Home Assistant](https://home-assistant.io/) usi
 
 ## Installation
 
-Navigate into your MagicMirror's `modules` folder and clone this repository:  
+Navigate into your MagicMirror's `modules` folder and clone this repository:
 `cd ~/MagicMirror/modules && git clone https://github.com/leinich/MMM-homeassistant-sensors.git`
 
-If you want to use icons for the sensors download the `MaterialDesignIcons` webfont from https://github.com/Templarian/MaterialDesign-Webfont/archive/master.zip and unzip the folder:  
+If you want to use icons for the sensors download the `MaterialDesignIcons` webfont from https://github.com/Templarian/MaterialDesign-Webfont/archive/master.zip and unzip the folder:
 `cd ~/MagicMirror/modules/MMM-homeassistant-sensors && wget https://github.com/Templarian/MaterialDesign-Webfont/archive/master.zip && unzip master.zip`
 
 ## Configuration
@@ -34,11 +34,12 @@ It is very simple to set up this module, a sample configuration looks like this:
 
 ## values option
 
-| Option           | Description                                                                                                                                |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `sensor`         | `entity_id` from Home Assistant. Please have a look at the states pages for the unique `entity_id` of your sensor                          |
-| `alertThreshold` | As soon as the measured value of the sensor exceeds the configured threshold, the entry will begin to 'blink'. <br><br> **Default:** `off` |
-| `icons`          | Icons object for the on/off status of sensor. see: [MaterialDesignIcons](https://materialdesignicons.com/)                                 |
+| Option           | Description                                                                                                                                                                                                 |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sensor`         | `entity_id` from Home Assistant. Please have a look at the states pages for the unique `entity_id` of your sensor                                                                                           |
+| `alertThreshold` | As soon as the measured value of the sensor exceeds the configured threshold, the entry will begin to 'blink'. <br><br> **Default:** `off`                                                                  |
+| `attributes`     | Array of sensor attributes to show. If not set, only show sensor state. If set, you can add as many attributes as you want, if you want to show the state as well add `'state'`. <br><br> **Default:** `[]` |
+| `icons`          | Icons object for the on/off status of sensor. see: [MaterialDesignIcons](https://materialdesignicons.com/)                                                                                                  |
 
 ## icons option
 

--- a/README.md
+++ b/README.md
@@ -101,4 +101,4 @@ modules: [{
 ## Special Thanks
 
 - [Michael Teeuw](https://github.com/MichMich) for creating the awesome [MagicMirror2](https://github.com/MichMich/MagicMirror/tree/develop) project that made this module possible.
-- [leinich](https://github.com/leinich) for creating the initial module that I used as guidance in creating this module.
+- [tkoeberl](https://github.com/tkoeberl) for creating the initial module that I used as guidance in creating this module.

--- a/README.md
+++ b/README.md
@@ -101,4 +101,4 @@ modules: [{
 ## Special Thanks
 
 - [Michael Teeuw](https://github.com/MichMich) for creating the awesome [MagicMirror2](https://github.com/MichMich/MagicMirror/tree/develop) project that made this module possible.
-- [tkoeberl](https://github.com/tkoeberl) for creating the initial module that I used as guidance in creating this module.
+- [leinich](https://github.com/leinich) for creating the initial module that I used as guidance in creating this module.


### PR DESCRIPTION
If set, the defined attributes will be shown with the separator ' | ' instead of only the state.
As special attribute, 'state' can be set too to combine it with other attributes.