### PR TITLE
allows sensor friendly_name to be overridden

### DIFF
--- a/MMM-homeassistant-sensors.js
+++ b/MMM-homeassistant-sensors.js
@@ -54,7 +54,7 @@ Module.register("MMM-homeassistant-sensors", {
           var sensor = values[i].sensor;
           var attributes = values[i].attributes;
           var val = this.getValue(data, sensor, attributes);
-          var name = this.getName(data, sensor);
+          var name = this.getName(data, values[i]);
           var unit = this.getUnit(data, sensor);
           var alertThreshold = values[i].alertThreshold;
           if (val) {
@@ -113,8 +113,13 @@ Module.register("MMM-homeassistant-sensors", {
     return "";
   },
   getName: function(data, value) {
+    //use the name from config if set
+    if (value.name && value.name !== "")
+      return value.name;
+
+    //find the sensor by entity_id and get it's friendly_name
     for (var i = 0; i < data.length; i++) {
-      if (data[i].entity_id == value) {
+      if (data[i].entity_id === value.sensor) {
         return data[i].attributes.friendly_name;
       }
     }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ It is very simple to set up this module, a sample configuration looks like this:
 | Option           | Description                                                                                                                                                                                                 |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `sensor`         | `entity_id` from Home Assistant. Please have a look at the states pages for the unique `entity_id` of your sensor                                                                                           |
+| `name`           | The name of the value to display. If you omit this, `friendly_name` from Home Assistant will be displayed.                                                                                                  |
 | `alertThreshold` | As soon as the measured value of the sensor exceeds the configured threshold, the entry will begin to 'blink'. <br><br> **Default:** `off`                                                                  |
 | `attributes`     | Array of sensor attributes to show. If not set, only show sensor state. If set, you can add as many attributes as you want, if you want to show the state as well add `'state'`. <br><br> **Default:** `[]` |
 | `icons`          | Icons object for the on/off status of sensor. see: [MaterialDesignIcons](https://materialdesignicons.com/)                                                                                                  |
@@ -74,6 +75,7 @@ modules: [{
 					]
 				}, {
 					sensor: "binary_sensor.sensor",
+					name: "Hallway Sensor",
 					icons: [{
 							"state_off": "run",
 							"state_on": "run-fast"


### PR DESCRIPTION
Thanks for this module!  I found it useful to be able to override Home Assistant's `friendly_name` attribute.  This PR allows you to do it by setting a new `name` config like so.

```javascript
{
	sensor: "binary_sensor.sensor",
	name: "Hallway Sensor",
	icons: [{
		"state_off": "run",
		"state_on": "run-fast"
	}]
}
```